### PR TITLE
Local color import

### DIFF
--- a/custom_logger_console_and_or_file/custom_logger.py
+++ b/custom_logger_console_and_or_file/custom_logger.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 
-from color import Color
+from .color import Color
 
 
 class CustomLogger(logging.getLoggerClass()):


### PR DESCRIPTION
Updated local 'color' import in customer logger. When calling class from elsewhere Python throws ModuleNotFountError.